### PR TITLE
Minor edits to parameter help text

### DIFF
--- a/examples/run_lm_finetuning.py
+++ b/examples/run_lm_finetuning.py
@@ -428,9 +428,9 @@ def main():
     parser.add_argument('--gradient_accumulation_steps', type=int, default=1,
                         help="Number of updates steps to accumulate before performing a backward/update pass.")
     parser.add_argument("--learning_rate", default=5e-5, type=float,
-                        help="The initial learning rate for Adam.")
+                        help="The initial learning rate for Adam optimizer.")
     parser.add_argument("--weight_decay", default=0.0, type=float,
-                        help="Weight deay if we apply some.")
+                        help="Weight decay if we apply some.")
     parser.add_argument("--adam_epsilon", default=1e-8, type=float,
                         help="Epsilon for Adam optimizer.")
     parser.add_argument("--max_grad_norm", default=1.0, type=float,


### PR DESCRIPTION
Matched language of line 431 to line 435 for additional clarity and consistency, and fixed a minor typo in line 433 by adding an omitted letter "c" to the word "decay".